### PR TITLE
Translate ExitCode.NO_TESTS_COLLECTED to ExitCode.OK

### DIFF
--- a/pytest_circleci_parallelized.py
+++ b/pytest_circleci_parallelized.py
@@ -71,6 +71,16 @@ def filter_tests_with_circleci(test_list):
     ]
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_cmdline_main(config: pytest.Config) -> None:
+    outcome = yield config
+    exit_code = outcome.get_result()
+
+    if circleci_parallelized_enabled(config) and exit_code == pytest.ExitCode.NO_TESTS_COLLECTED:
+        # It is possible that filtering of tests resulted in this worker having nothing to do - that is fine.
+        outcome.force_result(pytest.ExitCode.OK)
+
+
 def pytest_collection_modifyitems(session, config, items):
     if not circleci_parallelized_enabled(config):
         return

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -100,6 +100,24 @@ class ExcludedTestCase(unittest.TestCase):
 
 
 @mock.patch("subprocess.Popen", FakeCircleci)
+def test_with_circleci_parallelize_and_no_included_tests(testdir):
+    testdir.makepyfile(
+        """
+import unittest
+
+class ExcludedTestCase(unittest.TestCase):
+    def test_something(self):
+        assert True
+        """
+    )
+    result = testdir.runpytest("--circleci-parallelize")
+    result.stdout.fnmatch_lines(
+        ["*collected 1 item", "running 0 items due to CircleCI parallelism"]
+    )
+    assert result.ret == 0
+
+
+@mock.patch("subprocess.Popen", FakeCircleci)
 def test_without_circleci_parallelize(testdir):
     testdir.makepyfile(
         """


### PR DESCRIPTION
When splitting tests across workers, it is possible for a worker to end up with no tests to run (e.g. if there are 10 workers but only 9 tests). This should not cause that worker's test run to fail, so convert the `NO_TESTS_COLLECTED` (5) exit code to `OK` (0).

Fixes #6.